### PR TITLE
fix typo for array reference

### DIFF
--- a/lib/DataTables.pm
+++ b/lib/DataTables.pm
@@ -331,9 +331,9 @@ sub json {
     my %output = (
                  "sEcho" => $q->param('sEcho'),
                  "iTotalRecords" => $iTotal,
-                    "iTotalDisplayRecords" => $iFilteredTotal,
-                 "aaData" => ()
-                   );
+                 "iTotalDisplayRecords" => $iFilteredTotal,
+                 "aaData" => [],
+	);
 
     my $count = 0;
     my $patterns = $self->patterns;

--- a/lib/DataTables.pm
+++ b/lib/DataTables.pm
@@ -328,8 +328,9 @@ sub json {
     }
 
     # output hash
+	my $sEcho = $q->param('sEcho');
     my %output = (
-                 "sEcho" => $q->param('sEcho'),
+                 "sEcho" => $sEcho,
                  "iTotalRecords" => $iTotal,
                  "iTotalDisplayRecords" => $iFilteredTotal,
                  "aaData" => [],


### PR DESCRIPTION
otherwise, a warning about odd number of elements in hash may occur