### PR TITLE
Avoid "You tried to plan twice” message

### DIFF
--- a/t/01-data-tests-sqlite.t
+++ b/t/01-data-tests-sqlite.t
@@ -1,5 +1,5 @@
-use Test::More tests => 2;
-BEGIN { use_ok('DataTables') };
+use Test::More;
+use DataTables;
 use CGI::Simple;
 use DBI;
 use Data::Compare qw/Compare/;
@@ -7,6 +7,8 @@ use FindBin qw/$Bin/;
 
 eval "use DBD::SQLite";
 plan skip_all => "DBD::SQLite required for this test script." if $@;
+
+plan tests => 1;
 
 my @tests = (
     {


### PR DESCRIPTION
The skip condition throws a "You tried to plan twice" message in some cases (cf. CPANTesters reports). 
The duplicate test for the lib was removed and the planning was moved behind the skip tests condition. Should fix it.

cf. https://stackoverflow.com/questions/21626659/how-to-avoid-you-tried-to-plan-twice-at-testmore + https://github.com/hoytech/Log-File-Rolling/issues/1